### PR TITLE
fix(loader.options): use this.query to retrieve options

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,8 +144,9 @@ module.exports = function(input, map) {
   var webpack = this
 
   var userOptions = assign(
+    {},
     // user defaults
-    this.options.eslint || {},
+    ((webpack.options || {}).eslint) || webpack.query || {},
     // loader query string
     loaderUtils.getOptions(this)
   )


### PR DESCRIPTION
[#204] - follows guidelines https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202 

[<img width="908" alt="Module build failed: TypeError: Cannot read property 'eslint' of undefined" src="https://user-images.githubusercontent.com/5674833/36079700-e57ec8d4-0f7d-11e8-8bcb-4bf68eeb007c.png">](https://travis-ci.org/Code-Y/redux-fluent/jobs/340276371#L3222)
