### PR TITLE
Fix webpack hanging

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,8 +216,14 @@ module.exports = function(input, map) {
         if (err) {
           return callback(err)
         }
-        printLinterOutput(res || {}, config, webpack)
-        return callback(null, input, map)
+
+        try {
+          printLinterOutput(res || {}, config, webpack)
+        }
+        catch (e) {
+          err = e
+        }
+        return callback(err, input, map)
       }
     )
   }

--- a/test/fail-on-error/async-and-emit.js
+++ b/test/fail-on-error/async-and-emit.js
@@ -1,0 +1,56 @@
+var test = require("ava")
+
+var webpack = require("webpack")
+var conf = require("./utils/conf")
+
+test.cb("emits errors in async mode", function(t) {
+  t.plan(1)
+  webpack(conf(
+    {
+      cache: true,
+      entry: "./test/fixtures/error.js",
+    },{
+      failOnError: true,
+      emitError: true,
+      cache: true,
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    // console.log(stats.compilation.errors)
+    t.true(
+      stats.hasErrors(),
+      "a file that contains eslint errors should return error"
+    )
+    t.end()
+  })
+})
+
+test.cb("correctly indentifies a success", function(t) {
+  t.plan(1)
+  webpack(conf(
+    {
+      cache: true,
+      entry: "./test/fixtures/good.js",
+    },{
+      failOnError: true,
+      emitError: true,
+      cache: true,
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    // console.log(stats.compilation.errors)
+    t.false(
+      stats.hasErrors(),
+      "a file that doesn't contains eslint errors should not return errors"
+    )
+    t.end()
+  })
+})


### PR DESCRIPTION
This is an issue with an ancient version of webpack (1.X). It _feels_ like it also might be one with newer versions.

This PR correctly informs Webpack 1.X that an error has happened. It is only relevant when the `cache` options is enabled, due to `webpack.async()`.