### PR TITLE
Tests: Make formatter tests compatible with webpack >=4.12.0

### DIFF
--- a/test/formatter-multiple-entries.js
+++ b/test/formatter-multiple-entries.js
@@ -42,7 +42,7 @@ test.cb("eslint-loader can be configured to write multiple eslint result files",
 
             t.pass("File '" + filename + "' has been created")
             t.is(
-              error.message,
+              error.error.message,
               contents,
               "File '" + filename + "' Contents should equal output"
             )

--- a/test/formatter-write.js
+++ b/test/formatter-write.js
@@ -30,9 +30,9 @@ test.cb("eslint-loader can be configured to write eslint results to a file",
         console.log("### Here is a the output of the formatter")
         console.log(
           "# " +
-      stats.compilation.errors[0].message
-        .split("\n")
-        .join("\n# ")
+          stats.compilation.errors[0].error.message
+            .split("\n")
+            .join("\n# ")
         )
 
         fs.readFile(config.output.path + outputFilename,
@@ -44,7 +44,7 @@ test.cb("eslint-loader can be configured to write eslint results to a file",
               t.pass("File has been created")
 
               t.is(
-                stats.compilation.errors[0].message,
+                stats.compilation.errors[0].error.message,
                 contents,
                 "File Contents should equal output"
               )


### PR DESCRIPTION
Since the error output format changed in webpack/webpack#6542 to prefix the error with the loader name. Now the tests use the original `error.message` (which is unchanged), rather than the adjusted `message`.

Fixes #233.