### PR TITLE
Tests: Comment out remaining console.log() statements

### DIFF
--- a/test/formatter-custom.js
+++ b/test/formatter-custom.js
@@ -18,13 +18,13 @@ test.cb("eslint-loader can use custom formatter", function(t) {
       throw err
     }
 
-    console.log("### Here is a example of another formatter")
-    console.log(
-      "# " +
-      stats.compilation.errors[0].message
-        .split("\n")
-        .join("\n# ")
-    )
+    // console.log("### Here is a example of another formatter")
+    // console.log(
+    //   "# " +
+    //   stats.compilation.errors[0].message
+    //     .split("\n")
+    //     .join("\n# ")
+    // )
     t.truthy(
       stats.compilation.errors[0].message,
       "webpack have some output with custom formatters"

--- a/test/formatter-eslint.js
+++ b/test/formatter-eslint.js
@@ -15,13 +15,13 @@ test.cb("eslint-loader can use eslint formatter", function(t) {
       throw err
     }
 
-    console.log("### Here is a example of the default formatter")
-    console.log(
-      "# " +
-      stats.compilation.errors[0].message
-        .split("\n")
-        .join("\n# ")
-    )
+    // console.log("### Here is a example of the default formatter")
+    // console.log(
+    //   "# " +
+    //   stats.compilation.errors[0].message
+    //     .split("\n")
+    //     .join("\n# ")
+    // )
     t.truthy(stats.compilation.errors[0].message, "webpack have some output")
     t.end()
   })

--- a/test/formatter-write.js
+++ b/test/formatter-write.js
@@ -27,13 +27,13 @@ test.cb("eslint-loader can be configured to write eslint results to a file",
           throw err
         }
 
-        console.log("### Here is a the output of the formatter")
-        console.log(
-          "# " +
-          stats.compilation.errors[0].error.message
-            .split("\n")
-            .join("\n# ")
-        )
+        // console.log("### Here is a the output of the formatter")
+        // console.log(
+        //   "# " +
+        //   stats.compilation.errors[0].error.message
+        //     .split("\n")
+        //     .join("\n# ")
+        // )
 
         fs.readFile(config.output.path + outputFilename,
           "utf8", function(err, contents) {


### PR DESCRIPTION
Since they cause test output that gives the impression tests have failed when in fact all have passed, as well as hide the real cause of any failures.

Fixes #234.

The tests here will fail until #235 is merged (plus the changes there conflict with this PR).
I'll rebase this once #235 is merged.