### PR TITLE
Stop fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ See the [eslint docs](http://eslint.org/docs/developer-guide/nodejs-api#cliengin
 This option will enable
 [ESLint autofix feature](http://eslint.org/docs/user-guide/command-line-interface#fix).
 
-**Be careful: this option might cause webpack to enter an infinite build loop if
-some issues cannot be fixed properly.**
+**Be careful: this option will change source files.**
 
 #### `cache` (default: false)
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function printLinterOutput(res, config, webpack) {
     }
 
     // if enabled, use eslint auto-fixing where possible
-    if (config.fix && res.results[0].output) {
+    if (config.fix && (res.results[0].fixableErrorCount > 0 || res.results[0].fixableWarningCount)) {
       var eslint = require(config.eslintPath);
       eslint.CLIEngine.outputFixes(res);
     }

--- a/test/autofix-stop.js
+++ b/test/autofix-stop.js
@@ -1,0 +1,56 @@
+var fs = require("fs");
+
+var test = require("ava");
+var webpack = require("webpack");
+
+var conf = require("./utils/conf");
+
+var changed = false;
+
+// clone the "fixable" file, so that we do not lose the original contents
+// when the fixes are applied to disk
+test.before(function() {
+  fs.createReadStream("./test/fixtures/nonfixable.js")
+    .pipe(fs.createWriteStream("./test/fixtures/nonfixable-clone.js"))
+    .on("close", function() {
+      fs.watch("./test/fixtures/nonfixable-clone.js", function() {
+        changed = true;
+      });
+    });
+});
+
+test.cb("loader change file if there are no fixable errors/warnings", function(
+  t
+) {
+  t.plan(1);
+  webpack(
+    conf({
+      entry: "./test/fixtures/nonfixable-clone.js",
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            use: "./index?fix=true",
+            exclude: /node_modules/
+          }
+        ]
+      }
+    }),
+    function(err) {
+      if (err) {
+        throw err;
+      }
+      // console.log(stats.compilation.errors)
+      t.false(
+        changed,
+        "should not output to file again (triggering a recompile)"
+      );
+      t.end();
+    }
+  );
+});
+
+// remove the clone
+test.after.always(function() {
+  fs.unlinkSync("./test/fixtures/nonfixable-clone.js");
+});

--- a/test/autofix-stop.js
+++ b/test/autofix-stop.js
@@ -19,7 +19,7 @@ test.before(function() {
     });
 });
 
-test.cb("loader change file if there are no fixable errors/warnings", function(
+test.cb("loader shouldn't change file if there are no fixable errors/warnings", function(
   t
 ) {
   t.plan(1);

--- a/test/fixtures/nonfixable.js
+++ b/test/fixtures/nonfixable.js
@@ -1,0 +1,5 @@
+function foo() {
+  return stuff;
+}
+
+foo();


### PR DESCRIPTION
Stops eslint-loader to enter an infinite loop if there are non-fixable errors.