### PR TITLE
Fix autofix bug introduced in #244

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,12 @@ function printLinterOutput(res, config, webpack) {
     }
 
     // if enabled, use eslint auto-fixing where possible
-    if (config.fix && (res.results[0].fixableErrorCount > 0 || res.results[0].fixableWarningCount)) {
+    if (
+      config.fix &&
+      res.results[0].output &&
+      res.results[0].errorCount === 0 &&
+      res.results[0].warningCount === 0
+    ) {
       var eslint = require(config.eslintPath);
       eslint.CLIEngine.outputFixes(res);
     }


### PR DESCRIPTION
Fixes https://github.com/webpack-contrib/eslint-loader/issues/248 and duplicate https://github.com/webpack-contrib/eslint-loader/issues/249.

### Background 📜 
The documentation of [`fix`](https://eslint.bootcss.com/docs/developer-guide/nodejs-api/#cliengine) states:

> This can be a boolean or a function which will be provided each linting message and should return a boolean. True indicates that fixes should be included with the `output` report, and that errors and warnings should not be listed if they can be fixed. However, the files on disk will not be changed. To persist changes to disk, call `outputFixes()`.

### The Bug 🐞 
The condition that checks if the autofix results from `eslint` should be written is incorrect.

When a file is fixed `fixableErrorCount` and `fixableWarningCount` would usually be `0`, so after #244 files are no longer fixed (unless `eslint` runs out of [passes](https://github.com/eslint/eslint/blob/3943635e10c6cf47d3268c91baf9e24c07401af9/lib/linter.js#L1165), in which case `fixableErrorCount` or `fixableWarningCount` could still be `> 0`).

### The Fix 🔨 
In order to prevent loops, it should only write the file if there are __no more__ errors or warnings left, which ensures that in the most common case fixes are written to the file, and prevent loops in some corner cases where there are remaining errors or warnings.
