### PR TITLE
Fix autofix for eslint < 5 and revert warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ module.exports = {
         options: {
           // eslint options (if necessary)
         }
-      },
-    ],
-  },
+      }
+    ]
+  }
   // ...
-}
+};
 ```
 
 When using with transpiling loaders (like `babel-loader`), make sure they are in correct order
@@ -48,15 +48,12 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        use: [
-          "babel-loader",
-          "eslint-loader",
-        ],
-      },
-    ],
-  },
+        use: ["babel-loader", "eslint-loader"]
+      }
+    ]
+  }
   // ...
-}
+};
 ```
 
 To be safe, you can use `enforce: "pre"` section to check source files, not modified
@@ -71,17 +68,17 @@ module.exports = {
         enforce: "pre",
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: "eslint-loader",
+        loader: "eslint-loader"
       },
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: "babel-loader",
-      },
-    ],
-  },
+        loader: "babel-loader"
+      }
+    ]
+  }
   // ...
-}
+};
 ```
 
 ### Options
@@ -141,19 +138,19 @@ module.exports = {
 
             // you should return a string
             // DO NOT USE console.*() directly !
-            return "OUTPUT"
+            return "OUTPUT";
           }
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
 
 #### `eslintPath` (default: "eslint")
 
 Path to `eslint` instance that will be used for linting.  
-If the `eslintPath` is a folder like a official eslint, or specify a `formatter` option. now you dont have to install `eslint` . 
+If the `eslintPath` is a folder like a official eslint, or specify a `formatter` option. now you dont have to install `eslint` .
 
 ```js
 module.exports = {
@@ -165,12 +162,12 @@ module.exports = {
         exclude: /node_modules/,
         loader: "eslint-loader",
         options: {
-          eslintPath: path.join(__dirname, "reusable-eslint"),
+          eslintPath: path.join(__dirname, "reusable-eslint")
         }
-      },
-    ],
-  },
+      }
+    ]
   }
+};
 ```
 
 #### Errors and Warning
@@ -193,12 +190,12 @@ module.exports = {
         exclude: /node_modules/,
         loader: "eslint-loader",
         options: {
-          emitError: true,
+          emitError: true
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
 
 ##### `emitWarning` (default: `false`)
@@ -219,12 +216,12 @@ module.exports = {
         exclude: /node_modules/,
         loader: "eslint-loader",
         options: {
-          quiet: true,
+          quiet: true
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
 
 ##### `failOnWarning` (default: `false`)
@@ -241,12 +238,12 @@ module.exports = {
         exclude: /node_modules/,
         loader: "eslint-loader",
         options: {
-          failOnWarning: true,
+          failOnWarning: true
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
 
 ##### `failOnError` (default: `false`)
@@ -263,15 +260,16 @@ module.exports = {
         exclude: /node_modules/,
         loader: "eslint-loader",
         options: {
-          failOnError: true,
+          failOnError: true
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
 
 ##### `outputReport` (default: `false`)
+
 Write the output of the errors to a file, for example a checkstyle xml file for use for reporting on Jenkins CI
 
 The `filePath` is relative to the webpack config: output.path
@@ -288,16 +286,15 @@ module.exports = {
         loader: "eslint-loader",
         options: {
           outputReport: {
-            filePath: 'checkstyle.xml',
-            formatter: require('eslint/lib/formatters/checkstyle')
+            filePath: "checkstyle.xml",
+            formatter: require("eslint/lib/formatters/checkstyle")
           }
         }
-      },
-    ],
-  },
-}
+      }
+    ]
+  }
+};
 ```
-
 
 ## Gotchas
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+//var fs = require("fs");
 var assign = require("object-assign");
 var loaderUtils = require("loader-utils");
 var objectHash = require("object-hash");
@@ -70,7 +71,12 @@ function printLinterOutput(res, config, webpack) {
     }
 
     // if enabled, use eslint auto-fixing where possible
-    if (config.fix && (res.results[0].fixableErrorCount > 0 || res.results[0].fixableWarningCount)) {
+    if (
+      config.fix &&
+      (res.results[0].output !== res.src ||
+        res.results[0].fixableErrorCount > 0 ||
+        res.results[0].fixableWarningCount > 0)
+    ) {
       var eslint = require(config.eslintPath);
       eslint.CLIEngine.outputFixes(res);
     }
@@ -237,7 +243,11 @@ module.exports = function(input, map) {
         }
 
         try {
-          printLinterOutput(res || {}, config, webpack);
+          printLinterOutput(
+            assign({}, res || {}, { src: input }),
+            config,
+            webpack
+          );
         } catch (e) {
           err = e;
         }


### PR DESCRIPTION
This fixes my previous fix (which was apparently only for eslint versions greater than 5, which explicitly exposes fixable errors and warnings)