### PR TITLE
Add posibility to use absolute file path in outputReport.filePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ module.exports = {
 
 #### `eslintPath` (default: "eslint")
 
-Path to `eslint` instance that will be used for linting.  
+Path to `eslint` instance that will be used for linting.
 If the `eslintPath` is a folder like a official eslint, or specify a `formatter` option. now you dont have to install `eslint` .
 
 ```js
@@ -272,7 +272,7 @@ module.exports = {
 
 Write the output of the errors to a file, for example a checkstyle xml file for use for reporting on Jenkins CI
 
-The `filePath` is relative to the webpack config: output.path
+The `filePath` is an absolute path or relative to the webpack config: output.path
 You can pass in a different formatter for the output file, if none is passed in the default/configured formatter will be used
 
 ```js

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-//var fs = require("fs");
+var fs = require("fs");
+var path = require("path");
+
 var assign = require("object-assign");
 var loaderUtils = require("loader-utils");
 var objectHash = require("object-hash");
@@ -96,18 +98,34 @@ function printLinterOutput(res, config, webpack) {
         } else {
           reportOutput = messages;
         }
-        var filePath = loaderUtils.interpolateName(
-          webpack,
-          config.outputReport.filePath,
-          {
-            content: res.results
-              .map(function(r) {
-                return r.source;
-              })
-              .join("\n")
-          }
-        );
-        webpack.emitFile(filePath, reportOutput);
+
+        if (path.isAbsolute(config.outputReport.filePath)) {
+          fs.writeFile(config.outputReport.filePath, reportOutput, function(
+            err
+          ) {
+            if (err) {
+              throw new ESLintError(
+                "Can't save report to the file \"" +
+                  config.outputReport.filePath +
+                  '".\n' +
+                  err.message
+              );
+            }
+          });
+        } else {
+          var filePath = loaderUtils.interpolateName(
+            webpack,
+            config.outputReport.filePath,
+            {
+              content: res.results
+                .map(function(r) {
+                  return r.source;
+                })
+                .join("\n")
+            }
+          );
+          webpack.emitFile(filePath, reportOutput);
+        }
       }
 
       // default behavior: emit error only if we have errors

--- a/test/formatter-write.js
+++ b/test/formatter-write.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 var fs = require("fs");
+var path = require("path");
 
 var test = require("ava");
 var webpack = require("webpack");
@@ -7,7 +8,7 @@ var webpack = require("webpack");
 var conf = require("./utils/conf");
 
 test.cb(
-  "eslint-loader can be configured to write eslint results to a file",
+  "eslint-loader can be configured to write eslint results to a file (relative path)",
   function(t) {
     t.plan(2);
 
@@ -41,6 +42,57 @@ test.cb(
         err,
         contents
       ) {
+        if (err) {
+          t.fail("Expected file to have been created");
+        } else {
+          t.pass("File has been created");
+
+          t.is(
+            stats.compilation.errors[0].error.message,
+            contents,
+            "File Contents should equal output"
+          );
+        }
+
+        t.end();
+      });
+    });
+  }
+);
+
+test.cb(
+  "eslint-loader can be configured to write eslint results to a file (absolute path)",
+  function(t) {
+    t.plan(2);
+
+    var outputFilename = "outputReport-absolute.txt";
+    var outputFilepath = path.join(__dirname, "output", outputFilename);
+    var config = conf(
+      {
+        entry: "./test/fixtures/error.js"
+      },
+      {
+        formatter: require("eslint/lib/formatters/checkstyle"),
+        outputReport: {
+          filePath: outputFilepath
+        }
+      }
+    );
+
+    webpack(config, function(err, stats) {
+      if (err) {
+        throw err;
+      }
+
+      // console.log("### Here is a the output of the formatter")
+      // console.log(
+      //   "# " +
+      //   stats.compilation.errors[0].error.message
+      //     .split("\n")
+      //     .join("\n# ")
+      // )
+
+      fs.readFile(outputFilepath, "utf8", function(err, contents) {
         if (err) {
           t.fail("Expected file to have been created");
         } else {


### PR DESCRIPTION
Issue: https://github.com/webpack-contrib/eslint-loader/issues/265