### PR TITLE
fix: try load official formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ This can either be a `boolean` value or the cache directory path(ex: `'./.eslint
 If `cache: true` is used, the cache file is written to the `./node_modules/.cache` directory.
 This is the recommended usage.
 
-#### `formatter` (default: eslint stylish formatter)
+#### `formatter` (default: "stylish")
 
 Loader accepts a function that will have one argument: an array of eslint messages (object).
 The function must return the output as a string.
-You can use official eslint formatters.
+You can use official [eslint formatters](https://eslint.org/docs/user-guide/formatters/).
 
 ```js
 module.exports = {
@@ -126,7 +126,7 @@ module.exports = {
           // several examples !
 
           // default value
-          formatter: require("eslint/lib/formatters/stylish"),
+          formatter: "stylish",
 
           // community formatter
           formatter: require("eslint-friendly-formatter"),
@@ -287,7 +287,7 @@ module.exports = {
         options: {
           outputReport: {
             filePath: "checkstyle.xml",
-            formatter: require("eslint/lib/formatters/checkstyle")
+            formatter: "checkstyle"
           }
         }
       }
@@ -316,7 +316,9 @@ See [#129](https://github.com/webpack-contrib/eslint-loader/issues/129).
 ---
 
 ## Changelog
+
 [Changelog](CHANGELOG.md)
 
 ## License
+
 [MIT](./LICENSE)

--- a/index.js
+++ b/index.js
@@ -212,23 +212,18 @@ module.exports = function(input, map) {
       try {
         config.formatter = engines[configHash].getFormatter(config.formatter);
       } catch (_) {
-        // ignored
-      }
-    }
-
-    // Try to load external formatter
-    if (typeof config.formatter === "string") {
-      try {
-        config.formatter = require(config.formatter);
-        if (
-          config.formatter &&
-          typeof config.formatter !== "function" &&
-          typeof config.formatter.default === "function"
-        ) {
-          config.formatter = config.formatter.default;
+        try {
+          config.formatter = require(config.formatter);
+          if (
+            config.formatter &&
+            typeof config.formatter !== "function" &&
+            typeof config.formatter.default === "function"
+          ) {
+            config.formatter = config.formatter.default;
+          }
+        } catch (_) {
+          // ignored
         }
-      } catch (_) {
-        // ignored
       }
     }
 

--- a/test/formatter-official.js
+++ b/test/formatter-official.js
@@ -4,7 +4,7 @@ var webpack = require("webpack");
 
 var conf = require("./utils/conf");
 
-test.cb("eslint-loader can use oficial formatter", function(t) {
+test.cb("eslint-loader can use official formatter", function(t) {
   t.plan(1);
   webpack(
     conf(
@@ -20,7 +20,7 @@ test.cb("eslint-loader can use oficial formatter", function(t) {
         throw err;
       }
 
-      // console.log("### Here is a example of oficial formatter")
+      // console.log("### Here is a example of official formatter")
       // console.log(
       //   "# " +
       //   stats.compilation.errors[0].message
@@ -29,7 +29,7 @@ test.cb("eslint-loader can use oficial formatter", function(t) {
       // )
       t.truthy(
         stats.compilation.errors[0].message,
-        "webpack have some output with oficial formatter"
+        "webpack have some output with official formatter"
       );
       t.end();
     }

--- a/test/formatter-oficial.js
+++ b/test/formatter-oficial.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+var test = require("ava");
+var webpack = require("webpack");
+
+var conf = require("./utils/conf");
+
+test.cb("eslint-loader can use oficial formatter", function(t) {
+  t.plan(1);
+  webpack(
+    conf(
+      {
+        entry: "./test/fixtures/error.js"
+      },
+      {
+        formatter: "table"
+      }
+    ),
+    function(err, stats) {
+      if (err) {
+        throw err;
+      }
+
+      // console.log("### Here is a example of oficial formatter")
+      // console.log(
+      //   "# " +
+      //   stats.compilation.errors[0].message
+      //     .split("\n")
+      //     .join("\n# ")
+      // )
+      t.truthy(
+        stats.compilation.errors[0].message,
+        "webpack have some output with oficial formatter"
+      );
+      t.end();
+    }
+  );
+});


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
When using formatter as string try loading the [official formatters](https://eslint.org/docs/user-guide/formatters/)
```js
{
  formatter: 'table' // https://eslint.org/docs/user-guide/formatters/#table
}
```