### PR TITLE
fix module build failed error at Linter.parseResults

### DIFF
--- a/src/Linter.js
+++ b/src/Linter.js
@@ -113,10 +113,12 @@ export default class Linter {
 
   parseResults({ results }) {
     // add filename for each results so formatter can have relevant filename
-    results.forEach((r) => {
-      // eslint-disable-next-line no-param-reassign
-      r.filePath = this.loaderContext.resourcePath;
-    });
+    if (results) {
+      results.forEach((r) => {
+        // eslint-disable-next-line no-param-reassign
+        r.filePath = this.loaderContext.resourcePath;
+      });
+    }
 
     return results;
   }

--- a/test/Linter.test.js
+++ b/test/Linter.test.js
@@ -1,0 +1,22 @@
+import Linter from '../src/Linter';
+
+const loaderContext = { resourcePath: 'test' };
+const options = {
+  eslintPath: 'eslint',
+  ignore: false,
+  formatter: jest.fn(),
+};
+const res = { results: [{ filePath: '' }] };
+
+describe('Linter', () => {
+  const linter = new Linter(loaderContext, options);
+
+  it('should parse undefined results without error', () => {
+    // eslint-disable-next-line no-undefined
+    expect(linter.parseResults({})).toEqual(undefined);
+  });
+
+  it('should parse results correctly', () => {
+    expect(linter.parseResults(res)).toEqual([{ filePath: 'test' }]);
+  });
+});

--- a/test/Linter.test.js
+++ b/test/Linter.test.js
@@ -9,7 +9,10 @@ const options = {
 const res = { results: [{ filePath: '' }] };
 
 describe('Linter', () => {
-  const linter = new Linter(loaderContext, options);
+  let linter;
+  beforeAll(() => {
+    linter = new Linter(loaderContext, options);
+  });
 
   it('should parse undefined results without error', () => {
     expect(linter.parseResults({})).toBeUndefined();

--- a/test/Linter.test.js
+++ b/test/Linter.test.js
@@ -12,8 +12,7 @@ describe('Linter', () => {
   const linter = new Linter(loaderContext, options);
 
   it('should parse undefined results without error', () => {
-    // eslint-disable-next-line no-undefined
-    expect(linter.parseResults({})).toEqual(undefined);
+    expect(linter.parseResults({})).toBeUndefined();
   });
 
   it('should parse results correctly', () => {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
I am using the latest eslint-loader v3.0.0 on my rejected create-react-app and encountered this issue when I tried to start the app: `TypeError: Cannot read property 'forEach' of undefined`. This is the fix for this error.

<img width="877" alt="Screen Shot 2019-09-23 at 3 11 47 AM" src="https://user-images.githubusercontent.com/7416078/65393922-acd37580-ddb1-11e9-8ab7-ea81d1e3934a.png">

