### PR TITLE
chore: update dependency module object-hash to version 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8687,9 +8687,9 @@
       }
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-inspect": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fs-extra": "^8.1.0",
     "loader-fs-cache": "^1.0.2",
     "loader-utils": "^1.2.3",
-    "object-hash": "^1.3.1",
+    "object-hash": "^2.0.1",
     "schema-utils": "^2.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,10 +5656,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
-  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+object-hash@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.1.tgz#cef18a0c940cc60aa27965ecf49b782cbf101d96"
+  integrity sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA==
 
 object-inspect@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

changelog for `object-hash 2.0.0`
>v2.0.0
Only Node.js versions >= 6.0.0 are being tested in CI now. No other breaking changes were introduced.

v2.0.1 fixes: https://github.com/puleos/object-hash/issues/71

what i have done:
i am using vue-cli-plugin-electron-builder to build my electron appliaction and using this wonderful lib for logging purpose .

`eslint-loader(2.2.1)` and `winston-daily-rotate-file(4.3.0)` use `object-hash 1.3.1`, but i am stuck by issue https://github.com/puleos/object-hash/issues/71

so i manually replaced `node_modules/object-hash/dist/object_hash.js` with  the latest version(2.0.1)  and it works well.

### Breaking Changes

Only Node.js versions >= 6.0.0 are being tested in object-hash's CI now, so i think Node.js 6.0.0 or higher version is mandatory, but i'm not sure if this is a breaking change for eslint-loader

### Additional Info
